### PR TITLE
add destroy method to cleanup after colpick plugin

### DIFF
--- a/js/colpick.js
+++ b/js/colpick.js
@@ -434,6 +434,9 @@ For usage and examples: colpick.com/plugin
 						}
 					}
 				});
+			},
+			destroy: function(col, setCurrent) {
+				$('#' + $(this).data('colpickId')).remove();
 			}
 		};
 	}();
@@ -505,7 +508,8 @@ For usage and examples: colpick.com/plugin
 		colpick: colpick.init,
 		colpickHide: colpick.hidePicker,
 		colpickShow: colpick.showPicker,
-		colpickSetColor: colpick.setColor
+		colpickSetColor: colpick.setColor,
+		colpickDestroy: colpick.destroy
 	});
 	$.extend({
 		colpick:{ 


### PR DESCRIPTION
In the context of a single-page angular app, without a way to destroy the color picker after its parent directive is destroyed, orphaned dom elements are left behind and odd behavior is possible.  This small change allows removing the colpick dom element when destroy is called.
