### PR TITLE
Added support for 3 character hex code entry

### DIFF
--- a/js/colpick.js
+++ b/js/colpick.js
@@ -279,13 +279,22 @@ For usage and examples: colpick.com/plugin
 			},
 			fixHex = function (hex) {
 				var len = 6 - hex.length;
-				if (len > 0) {
-					var o = [];
-					for (var i=0; i<len; i++) {
-						o.push('0');
+				if (len == 3) {
+					var e = [];
+					for (var j = 0; j < len; j++) {
+						e.push(hex[j]);
+						e.push(hex[j]);
 					}
-					o.push(hex);
-					hex = o.join('');
+					hex = e.join('');
+				} else {
+					if (len > 0) {
+						var o = [];
+						for (var i = 0; i < len; i++) {
+							o.push('0');
+						}
+						o.push(hex);
+						hex = o.join('');
+					}
 				}
 				return hex;
 			},


### PR DESCRIPTION
This PR adds support for entering 3 character hex codes [as specificied in the CSS 2.1 spec](http://www.w3.org/TR/CSS21/syndata.html#color-units).

Quote:

> The three-digit RGB notation (#rgb) is converted into six-digit form (#rrggbb) by replicating digits, not by adding zeros. For example, #fb0 expands to #ffbb00.

This was one of the first things I attempted with the plugin. Let me know if its okay (there may be edge cases I haven't found where this circumvents your original usability).
