### PR TITLE
Add `appendTo` and `styles` options

### DIFF
--- a/js/colpick.js
+++ b/js/colpick.js
@@ -373,15 +373,15 @@ For usage and examples: colpick.com/plugin
 						setNewColor(options.color, cal.get(0));
 						//Append to body if flat=false, else show in place
 						if (options.flat) {
-							cal.appendTo(this).show();
-							cal.css({
+							cal.appendTo(options.appendTo || this).show();
+							cal.css(options.styles || {
 								position: 'relative',
 								display: 'block'
 							});
 						} else {
-							cal.appendTo(document.body);
+							cal.appendTo(options.appendTo || document.body);
 							$(this).on(options.showEvent, show);
-							cal.css({
+							cal.css(options.styles || {
 								position:'absolute'
 							});
 						}


### PR DESCRIPTION
`appendTo`: allows the caller to specify which element to append the
picker to.

By default for:
- `flat: true` -> `this`  (the element itself)
- `flat: false` -> `document.body`

`styles`: allows the caller to specify styles to be set on the picker

In concert, these options allow for a picker to be nested within a
scrolling container, styled with `position: relative`
