### PR TITLE
Prevent duplicate ids

### DIFF
--- a/js/colpick.js
+++ b/js/colpick.js
@@ -342,7 +342,7 @@ For usage and examples: colpick.com/plugin
 						//Store parts of the plugin
 						options.el = this;
 						options.hue = cal.find('div.colpick_hue_arrs');
-						huebar = options.hue.parent();
+						var huebar = options.hue.parent();
 						//Paint the hue bar
 						var UA = navigator.userAgent.toLowerCase();
 						var isIE = navigator.appName === 'Microsoft Internet Explorer';
@@ -356,7 +356,7 @@ For usage and examples: colpick.com/plugin
 								huebar.append(div);
 							}
 						} else {
-							stopList = stops.join(',');
+							var stopList = stops.join(',');
 							huebar.attr('style','background:-webkit-linear-gradient(top,'+stopList+'); background: -o-linear-gradient(top,'+stopList+'); background: -ms-linear-gradient(top,'+stopList+'); background:-moz-linear-gradient(top,'+stopList+'); -webkit-linear-gradient(top,'+stopList+'); background:linear-gradient(to bottom,'+stopList+'); ');
 						}
 						cal.find('div.colpick_hue').on('mousedown touchstart',downHue);

--- a/js/colpick.js
+++ b/js/colpick.js
@@ -175,9 +175,9 @@ For usage and examples: colpick.com/plugin
 				$(document).on('mouseup touchend',current,upSelector);
 				$(document).on('mousemove touchmove',current,moveSelector);
 
-				var payeX,pageY;
+				var pageX,pageY;
 				if(ev.type == 'touchstart') {
-					pageX = ev.originalEvent.changedTouches[0].pageX,
+					pageX = ev.originalEvent.changedTouches[0].pageX;
 					pageY = ev.originalEvent.changedTouches[0].pageY;
 				} else {
 					pageX = ev.pageX;
@@ -194,9 +194,9 @@ For usage and examples: colpick.com/plugin
 				return false;
 			},
 			moveSelector = function (ev) {
-				var payeX,pageY;
+				var pageX,pageY;
 				if(ev.type == 'touchmove') {
-					pageX = ev.originalEvent.changedTouches[0].pageX,
+					pageX = ev.originalEvent.changedTouches[0].pageX;
 					pageY = ev.originalEvent.changedTouches[0].pageY;
 				} else {
 					pageX = ev.pageX;

--- a/js/colpick.js
+++ b/js/colpick.js
@@ -439,7 +439,7 @@ For usage and examples: colpick.com/plugin
 	}();
 	//Color space convertions
 	var hexToRgb = function (hex) {
-		var hex = parseInt(((hex.indexOf('#') > -1) ? hex.substring(1) : hex), 16);
+		hex = parseInt(((hex.indexOf('#') > -1) ? hex.substring(1) : hex), 16);
 		return {r: hex >> 16, g: (hex & 0x00FF00) >> 8, b: (hex & 0x0000FF)};
 	};
 	var hexToHsb = function (hex) {

--- a/js/colpick.js
+++ b/js/colpick.js
@@ -289,6 +289,13 @@ For usage and examples: colpick.com/plugin
 				}
 				return hex;
 			},
+			getUniqueID = (function () {
+				var cnt = 0;
+				return function () {
+					cnt += 1;
+					return cnt;
+				};
+			})(),
 			restoreOriginal = function () {
 				var cal = $(this).parent();
 				var col = cal.data('colpick').origColor;
@@ -321,7 +328,7 @@ For usage and examples: colpick.com/plugin
 						var options = $.extend({}, opt);
 						options.origColor = opt.color;
 						//Generate and assign a random ID
-						var id = 'collorpicker_' + parseInt(Math.random() * 1000);
+						var id = 'collorpicker_' + getUniqueID();
 						$(this).data('colpickId', id);
 						//Set the tpl's ID and get the HTML
 						var cal = $(tpl).attr('id', id);


### PR DESCRIPTION
When having a bigger amount of color pickers on a page it would happen that
multiple pickers had the same id.

By using a counter that increments for each color picker the id is now
guaranteed to be unique.

Also includes some missing var declarations.
